### PR TITLE
Softcode battery cell number

### DIFF
--- a/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE.ino
+++ b/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE.ino
@@ -434,13 +434,14 @@ void loop() {
               commSerial.printf("   %.3f\n", (float)packCellInfo.CellVolt[i - 1] / 1000);
 
 
+              // This one sends just the the cell voltage: 3.700
+              //char data[6];
+              //snprintf(data, sizeof(data), "%.3f", (float)packCellInfo.CellVolt[i - 1] / 1000);
 
-              char data[6];
-              // snprintf(data, sizeof(data), "Hello, World! #%lu", msg_count++);
-              snprintf(data, sizeof(data), "%.3f", (float)packCellInfo.CellVolt[i - 1] / 1000);
-              // if (!broadcast_peer.send_message((uint8_t *)data, sizeof(data))) {
-              // Serial.println("Failed to broadcast message");
-              // }
+              
+              // This one sends the the cell number and cell voltage: 1:3.700, 2:3.703 2:3.699, etc.
+              char data[9];
+              snprintf(data, sizeof(data), "%i:%.3f", i-1, (float)packCellInfo.CellVolt[i - 1] / 1000);
 
 
 

--- a/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE.lisp
+++ b/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE.lisp
@@ -6,13 +6,12 @@
 
 (print (get-mac-addr))
 (print (wifi-get-chan))
-;(set-bms-val 'bms-cell-num 26)
 (def cell-index 0)
 (def current-cell 0)
 
 (esp-now-start)
 
-(def cell-total-count 26)
+(def cell-total-count 13)
 (set-bms-val 'bms-cell-num cell-total-count)
 ;(print "HI")
 
@@ -23,14 +22,10 @@
 (defun proc-data (src des data)
 ;        (print (list data))
     (progn
-;         (print (list data))
-         (if (<= cell-index cell-total-count) (def current-cell data)) 
-;         (print "HI")
-         (print (list current-cell))
-         (set-bms-val 'bms-v-cell cell-index (str-to-f current-cell))
-         (def cell-index (+ cell-index 1))
-         (if (>= cell-index cell-total-count) (def cell-index 0))
-;         (send-bms-can)
+         (def cell-index (ix (str-split data ":") 0))
+         (def current-cell (ix (str-split data ":") 1))
+         (print cell-index current-cell)
+         (set-bms-val 'bms-v-cell (str-to-i cell-index) (str-to-f current-cell)) ;works
 
     );progn    
 );proc-data
@@ -51,4 +46,3 @@
 
 ; Enable the custom app data event
 (event-enable 'event-esp-now-rx)
-

--- a/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE.lisp
+++ b/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE/JBD_BMS_BLE_VESC_EXPRESS_BRIDGE.lisp
@@ -4,6 +4,11 @@
 ;Created: on September 4 2024
 ;Author: A-damW, https://github.com/A-damW
 
+; ----------------- Begin user config -----------------
+; Set the total count of cells in your pack
+(def cell-total-count 39)
+; ----------------- End user config -----------------
+
 (print (get-mac-addr))
 (print (wifi-get-chan))
 (def cell-index 0)
@@ -11,7 +16,6 @@
 
 (esp-now-start)
 
-(def cell-total-count 13)
 (set-bms-val 'bms-cell-num cell-total-count)
 ;(print "HI")
 
@@ -22,10 +26,12 @@
 (defun proc-data (src des data)
 ;        (print (list data))
     (progn
+
          (def cell-index (ix (str-split data ":") 0))
          (def current-cell (ix (str-split data ":") 1))
          (print cell-index current-cell)
-         (set-bms-val 'bms-v-cell (str-to-i cell-index) (str-to-f current-cell)) ;works
+         (set-bms-val 'bms-v-cell (str-to-i cell-index) (str-to-f current-cell))
+         ;(send-bms-can)
 
     );progn    
 );proc-data

--- a/README.md
+++ b/README.md
@@ -2,4 +2,5 @@
 An ESP32 firmware and companion LispBM script to connect multiple JBD ble BMSes to VESC-EXPRESS via ESPNOW
 
 # TODO
-Write a better readme.
+Write a better readme. (Ongoing...)
+1. Softcode the battery cell number, i.e. tally the total cell count on the esp32 bridge, and send over esp-now to lisp on vesc-express.


### PR DESCRIPTION
This pull sends the battery cell number separated by a colon ':'  on esp-now to lisp on vesc-express.